### PR TITLE
Update chess.com archives data

### DIFF
--- a/src/archives.gs
+++ b/src/archives.gs
@@ -15,9 +15,10 @@ function updateArchives() {
 	U.ensureHeaders(archivesSheet, CONST.ARCHIVES_HEADERS);
 	var hmap = U.getHeaderIndexMap(archivesSheet);
 
-	// 1) Fetch overall archives list with ETag
+	// 1) Fetch overall archives list with ETag (persist by username)
 	var listUrl = 'https://api.chess.com/pub/player/' + encodeURIComponent(username) + '/games/archives';
-	var prevEtag = ''; // Optionally persisted; for now read last row etag of list via Properties if desired
+	var listEtagKey = 'archives_list_etag__' + username.toLowerCase();
+	var prevEtag = U.getScriptProp(listEtagKey) || '';
 	var resp = HTTP.fetchWithEtag(listUrl, prevEtag);
 	if (resp.status === 304) {
 		LOG.info('archives', 'archivesList', listUrl, 'Not Modified');
@@ -26,6 +27,7 @@ function updateArchives() {
 		if (!Array.isArray(arr)) arr = [];
 		appendNewArchivesRows(archivesSheet, hmap, arr);
 		LOG.info('archives', 'archivesList', listUrl, 'Fetched archives list', { count: arr.length });
+		if (resp.etag) U.setScriptProp(listEtagKey, resp.etag);
 	} else {
 		LOG.warn('archives', 'archivesList', listUrl, 'Unexpected status ' + resp.status);
 	}
@@ -33,9 +35,9 @@ function updateArchives() {
 	// 2) Establish activity flags
 	establishArchiveActivity(archivesSheet, hmap);
 
-	// 3) Optional: per-archive change checks
+	// 3) Optional: per-archive change checks (scoped via Settings)
 	if (checkChanges) {
-		checkChangedArchives(archivesSheet, hmap, username, maxArchives);
+		checkChangedArchives(archivesSheet, hmap, username, maxArchives, settings);
 	}
 
 	LOG.info('archives', 'updateArchives:end', '', 'Done');
@@ -111,38 +113,94 @@ function establishArchiveActivity(sheet, hmap) {
 	sheet.getRange(2, 1, updates.length, CONST.ARCHIVES_HEADERS.length).setValues(updates);
 }
 
-function checkChangedArchives(sheet, hmap, username, maxArchives) {
+function checkChangedArchives(sheet, hmap, username, maxArchives, settings) {
 	var lastRow = sheet.getLastRow();
 	if (lastRow < 2) return;
-	var values = sheet.getRange(2, 1, lastRow - 1, CONST.ARCHIVES_HEADERS.length).getValues();
+	var allRows = sheet.getRange(2, 1, lastRow - 1, CONST.ARCHIVES_HEADERS.length).getValues();
+	var indices = scopeArchiveRowIndices(allRows, hmap, settings);
 	var checked = 0;
-	for (var i = 0; i < values.length; i++) {
+	for (var idx = 0; idx < indices.length; idx++) {
 		if (checked >= maxArchives) break;
-		var row = values[i];
+		var i = indices[idx];
+		var row = allRows[i];
 		var url = String(row[hmap['archive_url'] - 1] || '');
 		if (!url) continue;
 		var etag = String(row[hmap['etag'] - 1] || '');
 		var resp = HTTP.fetchWithEtag(url, etag);
-		var changed = false;
-		if (resp.status === 304) {
-			changed = false;
-		} else if (resp.status >= 200 && resp.status < 300) {
-			// Month body available; compare game count or last URL if needed
+		if (resp.status >= 200 && resp.status < 300) {
 			var games = (resp.json && (resp.json.games || resp.json['games'])) || [];
 			var newCount = Array.isArray(games) ? games.length : 0;
 			var oldCount = Number(row[hmap['game_count'] - 1] || 0);
-			if (resp.etag && resp.etag !== etag) changed = true;
-			else if (newCount !== oldCount) changed = true;
+			var newLastUrl = '';
+			if (Array.isArray(games) && games.length) {
+				var best = games[0];
+				for (var g = 1; g < games.length; g++) {
+					var a = Number((best && best.end_time) || 0);
+					var b = Number((games[g] && games[g].end_time) || 0);
+					if (b >= a) best = games[g];
+				}
+				newLastUrl = String((best && best.url) || games[games.length - 1].url || '');
+			}
+			var lastSeen = String(row[hmap['last_seen_url'] - 1] || '');
+			var etagChanged = !!(resp.etag && resp.etag !== etag);
+			var countChanged = newCount !== oldCount;
+			var lastUrlChanged = newLastUrl && lastSeen && newLastUrl !== lastSeen;
 			row[hmap['etag'] - 1] = resp.etag || row[hmap['etag'] - 1];
 			row[hmap['last_modified'] - 1] = resp.lastModified || row[hmap['last_modified'] - 1];
 			row[hmap['game_count'] - 1] = newCount;
+			if (etagChanged || countChanged || lastUrlChanged) {
+				LOG.info('archives', 'changed', url, 'Archive changed', { etagChanged: etagChanged, countChanged: countChanged, lastUrlChanged: lastUrlChanged, newCount: newCount });
+			} else {
+				LOG.debug('archives', 'unchanged', url, 'Archive unchanged');
+			}
+		} else if (resp.status === 304) {
+			// unchanged
 		} else {
 			LOG.warn('archives', 'checkChanged', url, 'HTTP ' + resp.status);
 		}
 		row[hmap['last_checked_changes_ts'] - 1] = U.now();
 		row[hmap['updated_ts'] - 1] = U.now();
-		values[i] = row;
+		sheet.getRange(i + 2, 1, 1, CONST.ARCHIVES_HEADERS.length).setValues([row]);
 		checked++;
 	}
-	sheet.getRange(2, 1, values.length, CONST.ARCHIVES_HEADERS.length).setValues(values);
+}
+
+function scopeArchiveRowIndices(values, hmap, settings) {
+	var mode = String(settings.scope_archives || 'all');
+	var out = [];
+	var idStart = Number(settings.scope_archives_id_start || '');
+	var idEnd = Number(settings.scope_archives_id_end || '');
+	var dateStart = String(settings.scope_archives_date_start || '').trim();
+	var dateEnd = String(settings.scope_archives_date_end || '').trim();
+	var startYM = parseYYYYMM(dateStart);
+	var endYM = parseYYYYMM(dateEnd);
+	for (var i = 0; i < values.length; i++) {
+		var row = values[i];
+		if (mode === 'active_only') {
+			var active = !!row[hmap['is_active'] - 1];
+			if (!active) continue;
+		} else if (mode === 'id_range') {
+			var idVal = Number(row[hmap['id'] - 1] || 0);
+			if (idStart && idVal < idStart) continue;
+			if (idEnd && idVal > idEnd) continue;
+		} else if (mode === 'date_range') {
+			var year = Number(row[hmap['year'] - 1] || 0);
+			var month = Number(row[hmap['month'] - 1] || 0);
+			var ym = year * 100 + month;
+			if (startYM && ym < startYM) continue;
+			if (endYM && ym > endYM) continue;
+		}
+		out.push(i);
+	}
+	return out;
+}
+
+function parseYYYYMM(s) {
+	if (!s) return 0;
+	var parts = String(s).split('-');
+	if (parts.length !== 2) return 0;
+	var y = Number(parts[0]);
+	var m = Number(parts[1]);
+	if (!y || !m) return 0;
+	return y * 100 + m;
 }

--- a/src/utils.gs
+++ b/src/utils.gs
@@ -78,6 +78,22 @@ var U = (function() {
 		if (writes.length) sh.getRange(sh.getLastRow() + 1, 1, writes.length, 2).setValues(writes);
 	}
 
+	function getScriptProp(key) {
+		try {
+			return PropertiesService.getScriptProperties().getProperty(String(key));
+		} catch (e) {
+			return null;
+		}
+	}
+
+	function setScriptProp(key, value) {
+		try {
+			PropertiesService.getScriptProperties().setProperty(String(key), String(value));
+		} catch (e) {
+			// ignore
+		}
+	}
+
 	return {
 		getSpreadsheet: getSpreadsheet,
 		getOrCreateSheet: getOrCreateSheet,
@@ -86,6 +102,8 @@ var U = (function() {
 		readSettings: readSettings,
 		toSheetDate: toSheetDate,
 		now: now,
-		setKeyValueSettings: setKeyValueSettings
+		setKeyValueSettings: setKeyValueSettings,
+		getScriptProp: getScriptProp,
+		setScriptProp: setScriptProp
 	};
 })();


### PR DESCRIPTION
Enhance `updateArchives` to use ETag for the archives list, implement settings-based scoping for change checks, and add fallback logic for detecting monthly archive changes.

The `updateArchives` function now consolidates fetching the main archives list (with ETag persistence), establishing archive activity, and optionally checking individual monthly archives for changes based on user settings. Monthly archive change detection is improved with a fallback to compare game count and last game URL when ETags are insufficient.

---
<a href="https://cursor.com/background-agent?bcId=bc-b068b1fa-7437-4451-bf9e-0f3b9666dd01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b068b1fa-7437-4451-bf9e-0f3b9666dd01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

